### PR TITLE
Create Nuclei vulnerability mgmt scan for target IPs

### DIFF
--- a/Nuclei vulnerability mgmt scan for target IPs
+++ b/Nuclei vulnerability mgmt scan for target IPs
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Check if prips is installed; if not, install it
+if ! command -v prips &> /dev/null; then
+    echo "prips not found, installing..."
+    apt-get update && apt-get install -y prips
+fi
+
+# Function to generate target list for /24 subnet using prips
+generate_targets_24() {
+  local base_ip="$1"
+  # Generate IPs in the range base_ip.0 to base_ip.254 using prips
+  prips "${base_ip}.0" "${base_ip}.254" > targets.txt
+}
+
+# Function to generate target list for /17 subnet using prips
+generate_targets_17() {
+  local base_ip="$1"
+  # Generate IPs in the range base_ip.0.0 to base_ip.127.255 using prips
+  prips "${base_ip}.0.0" "${base_ip}.127.255" > targets.txt
+}
+
+# Prompt user for IP subnet and template path
+read -p "Enter IP subnet (e.g., 10.7.1.0/24 or 10.7.0.0/17): " IP_SUBNET
+read -p "Enter path to Nuclei templates: " TEMPLATE_PATH
+
+# Determine subnet type and base IP
+subnet_type="${IP_SUBNET#*/}"
+base_ip="${IP_SUBNET%/*}"
+
+# Check if input subnet is valid
+if ! [[ "$subnet_type" =~ ^(24|17)$ ]]; then
+  echo "Invalid subnet type. Must be 24 or 17."
+  exit 1
+fi
+
+# Check if template path exists
+if ! [[ -d "$TEMPLATE_PATH" ]]; then
+  echo "Template path does not exist."
+  exit 1
+fi
+
+# Choose appropriate function based on subnet type
+case "$subnet_type" in
+  24) generate_targets_24 "$base_ip";;
+  17) generate_targets_17 "$base_ip";;
+  *) echo "Unsupported subnet type"; exit 1;;
+esac
+
+# Run Nuclei scan with generated target list
+nuclei -l targets.txt -t "$TEMPLATE_PATH"
+
+# Cleanup
+rm targets.txt


### PR DESCRIPTION
This script generates a list of targets for a Nuclei scan based on a given IP subnet and template path. It uses the prips tool to generate a list of IP addresses in the subnet and then formats them according to the template provided. The script also includes some basic error handling and input validation to ensure that the user provides a valid IP subnet and template path. The script first prompts the user to enter an IP subnet and template path, and then uses parameter expansion to extract the subnet type and base IP from the input subnet. It then uses a case statement to choose the appropriate function to generate the target list based on the subnet type. The generate_targets_24 function generates a list of IP addresses in the range ${base_ip}.0 to ${base_ip}.254, while the generate_targets_17 function generates a list of IP addresses in the range ${base_ip}.0.0 to ${base_ip}.127.255. Once the target list is generated, the script runs the Nuclei scan using the nuclei command and the generated target list. Finally, the script cleans up the temporary file used to store the target list. This script can be useful for automating Nuclei scans in a variety of environments, including cloud and on-premises networks.